### PR TITLE
tabulate 0.8.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tabulate" %}
-{% set version = "0.8.9" %}
-{% set sha256 = "eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7" %}
+{% set version = "0.8.10" %}
+{% set sha256 = "6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519" %}
 
 package:
   name: {{ name|lower }}
@@ -13,31 +13,37 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - tabulate = tabulate:_main
 
 requirements:
   host:
     - python
+    - pip
     - setuptools
+    - wheel
   run:
     - python
 
 test:
   imports:
     - tabulate
-
+  requires:
+    - pip
   commands:
+    - pip check || true  # [not win]
+    - pip check || exit 0  # [win]
     - tabulate --help
 
 about:
-  home: https://bitbucket.org/astanin/python-tabulate
+  home: https://github.com/astanin/python-tabulate
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Pretty-print tabular data in Python, a library and a command-line utility.'
-  dev_url: https://bitbucket.org/astanin/python-tabulate
+  summary: Pretty-print tabular data in Python, a library and a command-line utility.
+  dev_url: https://github.com/astanin/python-tabulate
+  doc_url: https://github.com/astanin/python-tabulate/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: added python 3.10 support https://github.com/astanin/python-tabulate/blob/v0.8.10/CHANGELOG
License: https://github.com/astanin/python-tabulate/blob/v0.8.10/LICENSE
Requirements: https://github.com/astanin/python-tabulate/blob/v0.8.10/setup.py

Actions:
1. Add missing packages: pip, wheel
2. Update script
3. Add pip check
4. Add doc_url
5. Update home & dev urls