### PR TITLE
Update to 0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - setuptools_scm
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "tabulate" %}
-{% set version = "0.8.10" %}
-{% set sha256 = "6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519" %}
+{% set version = "0.9.0" %}
+{% set sha256 = "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - tabulate = tabulate:_main
 
@@ -32,8 +32,7 @@ test:
   requires:
     - pip
   commands:
-    - pip check || true  # [not win]
-    - pip check || exit 0  # [win]
+    - pip check
     - tabulate --help
 
 about:
@@ -42,6 +41,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Pretty-print tabular data in Python, a library and a command-line utility.
+  description: Pretty-print tabular data in Python, a library and a command-line utility.
   dev_url: https://github.com/astanin/python-tabulate
   doc_url: https://github.com/astanin/python-tabulate/blob/master/README.md
 


### PR DESCRIPTION
Upstream: https://github.com/astanin/python-tabulate/tree/v0.9.0

Channel: defaults